### PR TITLE
Fixed pageCount math operation

### DIFF
--- a/lib/mongoose-paginate.js
+++ b/lib/mongoose-paginate.js
@@ -1,4 +1,3 @@
-
 /**
  * @list dependencies
  **/
@@ -28,7 +27,7 @@ mongoose.Model.paginate = function(q, pageNumber, resultsPerPage, callback) {
         if (error) {
           callback(error, null, null);
         } else {
-          var pageCount = Math.floor(count / resultsPerPage);
+          var pageCount = Math.ceil(count / resultsPerPage);
           if (pageCount == 0) {
             pageCount = 1;
           };


### PR DESCRIPTION
You have to return the smallest integer greater than or equal to a number.  
So if count/resultsPerPage = 1.6 you need pageCount=2 and not =1 ;)
