### PR TITLE
Integrated async and fixed tests for collection removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# mongoose-paginate [![Build Status](https://secure.travis-ci.org/edwardhotchkiss/mongoose-paginate.png)](http://travis-ci.org/edwardhotchkiss/mongoose-paginate) [![Git Tip](http://img.shields.io/gittip/edwardhotchkiss.svg)](https://www.gittip.com/edwardhotchkiss/) 
+# mongoose-paginate [![Build Status](https://secure.travis-ci.org/edwardhotchkiss/mongoose-paginate.png)](http://travis-ci.org/edwardhotchkiss/mongoose-paginate) [![Git Tip](http://img.shields.io/gittip/edwardhotchkiss.svg)](https://www.gittip.com/edwardhotchkiss/)
 
 > Mongoose ORM (NodeJS/MongoDB) Document Query Pagination
 
@@ -9,11 +9,11 @@
 $ npm install mongoose-paginate
 ```
 
-## Usage 
+## Usage
 
 #### Basic
 
-```javascript
+```js
 
 /*
  * basic example usage of `mongoose-pagination`
@@ -36,7 +36,7 @@ MyModel.paginate({}, 2, 10, function(error, pageCount, paginatedResults, itemCou
 
 #### Advanced
 
-```javascript
+```js
 
 /*
  * basic example usage of `mongoose-pagination`
@@ -67,6 +67,10 @@ $ npm test
 
 [0]: http://edwardhotchkiss.com/
 
+
+### Contributors
+
+* [Nick Baugh](https://github.com/niftylettuce)
 
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/edwardhotchkiss/mongoose-paginate/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
 

--- a/lib/mongoose-paginate.js
+++ b/lib/mongoose-paginate.js
@@ -4,6 +4,7 @@
  */
 
 var mongoose = require('mongoose');
+var async = require('async');
 
 /*
  * @method paginate
@@ -15,7 +16,7 @@ var mongoose = require('mongoose');
 
 mongoose.Model.paginate = function(q, pageNumber, resultsPerPage, callback, options) {
   var model = this;
-  var options = options || {};
+  options = options || {};
   var columns = options.columns || null;
   var sortBy = options.sortBy || {
     _id : 1
@@ -23,26 +24,26 @@ mongoose.Model.paginate = function(q, pageNumber, resultsPerPage, callback, opti
   var populate = options.populate || null;
   callback = callback || function() {};
   var skipFrom = (pageNumber * resultsPerPage) - resultsPerPage;
-  if (columns == null) {
-    var query = model.find(q).skip(skipFrom).limit(resultsPerPage).sort(sortBy);
-  } else {
-    var query = model.find(q).select(options.columns).skip(skipFrom).limit(resultsPerPage).sort(sortBy);
+  var query = model.find(q);
+  if (columns !== null) {
+    query = query.select(options.columns);
   }
+  query = query.skip(skipFrom).limit(resultsPerPage).sort(sortBy);
   if (populate) {
     query = query.populate(populate);
   }
-  query.exec(function(error, results) {
-    if (error) {
-      callback(error);
-    } else {
-      model.count(q, function(error, count) {
-        if (error) {
-          callback(error);
-        } else {
-          callback(null, Math.ceil(count / resultsPerPage) || 1, results, count);
-        };
-      });
-    };
+  async.parallel({
+    results: function(callback) {
+      query.exec(callback);
+    },
+    count: function(callback) {
+      model.count(q, function(err, count) {
+        callback(err, count);
+      })
+    }
+  }, function(err, data) {
+    if (err) return callback(err);
+    callback(null, Math.ceil(data.count / resultsPerPage) || 1, data.results, data.count);
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -1,35 +1,48 @@
 {
-  "author":"Edward Hotchkiss <edward@edwardhotchkiss.com>",
-  "name":"mongoose-paginate",
-  "description":"Mongoose ORM (NodeJS/MongoDB) Document Query Pagination",
-  "version":"2.2.0",
-  "contributors":[
-    { "name": "Edward Hotchkiss", "email": "edward@edwardhotchkiss.com" }
+  "author": "Edward Hotchkiss <edward@edwardhotchkiss.com>",
+  "name": "mongoose-paginate",
+  "description": "Mongoose ORM (NodeJS/MongoDB) Document Query Pagination",
+  "version": "2.2.0",
+  "contributors": [
+    {
+      "name": "Edward Hotchkiss",
+      "email": "edward@edwardhotchkiss.com"
+    }
   ],
-  "repository":{
-    "type":"git",
-    "url":"git://github.com/edwardhotchkiss/mongoose-paginate.git"
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/edwardhotchkiss/mongoose-paginate.git"
   },
   "bugs": {
     "url": "https://github.com/edwardhotchkiss/mongoose-paginate/issues"
   },
   "homepage": "http://github.com/edwardhotchkiss/mongoose-paginate/",
-  "keywords":["mongoose","paginate","sort","results","page","populate"],
-  "engines":{
-    "node":">= 0.8.0"
+  "keywords": [
+    "mongoose",
+    "paginate",
+    "sort",
+    "results",
+    "page",
+    "populate"
+  ],
+  "engines": {
+    "node": ">= 0.8.0"
   },
-  "dependencies":{
-    "mongoose":">=3.8.8"
+  "dependencies": {
+    "async": "^0.9.0",
+    "mongoose": ">=3.8.8"
   },
-  "devDependencies":{
-    "vows":"0.7.0"
+  "main": "./lib/mongoose-paginate",
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://github.com/edwardhotchkiss/mongoose-paginate/LICENSE"
+    }
+  ],
+  "scripts": {
+    "test": "vows test/*.test.js --spec"
   },
-  "main":"./lib/mongoose-paginate",
-  "licenses":[{
-    "type":"MIT",
-    "url":"http://github.com/edwardhotchkiss/mongoose-paginate/LICENSE"
-  }],
-  "scripts":{
-    "test":"vows test/*.test.js --spec"
+  "devDependencies": {
+    "vows": "^0.7.0"
   }
 }


### PR DESCRIPTION
I've added `async` to perform the DB queries for `.exec` and `.count` in parallel, in the hope that it would optimize performance for `mongoose-paginate`.  I've also added tests to wipe the "TestEntry" and "TestSubEntry" collection records before the tests begin.
