### PR TITLE
Let populate support multiple arguments

### DIFF
--- a/lib/mongoose-paginate.js
+++ b/lib/mongoose-paginate.js
@@ -30,7 +30,11 @@ function paginate(q, pageNumber, resultsPerPage, callback, options) {
     query.sort(sortBy);
   }
   if (populate) {
-    query = query.populate(populate);
+    if (Array.isArray(populate)) {
+      query = query.populate.apply(query, populate);
+    } else {
+      query = query.populate(populate);
+    }
   }
   async.parallel({
     results: function(callback) {


### PR DESCRIPTION
This is required when need to pass into `query.populate` more than one argument.
