### PR TITLE
Add prev and next return values

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Promise fulfilled with object having properties:
 * `limit` {Number} - Limit that was used
 * `[page]` {Number} - Only if specified or default `page`/`offset` values were used 
 * `[pages]` {Number} - Only if `page` specified or default `page`/`offset` values were used 
+* `[prev]` {Number} - Only if there is a previous page to go to.
+* `[next]` {Number} - Only if there is a next page to go to.
 * `[offset]` {Number} - Only if specified or default `page`/`offset` values were used
 
 ### Examples

--- a/index.js
+++ b/index.js
@@ -75,6 +75,16 @@ function paginate(query, options, callback) {
     if (page !== undefined) {
       result.page = page;
       result.pages = Math.ceil(data.count / limit) || 1;
+      var prev = page - 1;
+      var next = page + 1;
+      
+      if (prev > 0) {
+        result.prev = prev;
+      }
+      
+      if (next <= result.pages) {
+        result.next = next;
+      }
     }
     if (typeof callback === 'function') {
       return callback(null, result);

--- a/index.js
+++ b/index.js
@@ -75,8 +75,8 @@ function paginate(query, options, callback) {
     if (page !== undefined) {
       result.page = page;
       result.pages = Math.ceil(data.count / limit) || 1;
-      var prev = page - 1;
-      var next = page + 1;
+      let prev = page - 1;
+      let next = page + 1;
       
       if (prev > 0) {
         result.prev = prev;

--- a/tests/index.js
+++ b/tests/index.js
@@ -113,7 +113,33 @@ describe('mongoose-paginate', function() {
         expect(result.limit).to.equal(20);
         expect(result.page).to.equal(1);
         expect(result.pages).to.equal(5);
+        expect(result.next).to.equal(2);
+        expect(result.prev).to.be.undefined;
         expect(result).to.not.have.property('offset');
+      });
+    });
+    it('on the first page', function() {
+      return Book.paginate({}, { page: 1, limit: 20 }).then(function(result) {
+        expect(result.next).to.equal(2);
+        expect(result).to.not.have.property('prev');
+      });
+    });
+    it('on the last page', function() {
+      return Book.paginate({}, { page: 5, limit: 20 }).then(function(result) {
+        expect(result.prev).to.equal(4);
+        expect(result).to.not.have.property('next');
+      });
+    });
+    it('on the middle page', function() {
+      return Book.paginate({}, { page: 3, limit: 20 }).then(function(result) {
+        expect(result.prev).to.equal(2);
+        expect(result.next).to.equal(4);
+      });
+    });
+    it('with page 1 and limit', function() {
+      return Book.paginate({}, { page: 1, limit: 20 }).then(function(result) {
+        expect(result.next).to.equal(2);
+        expect(result).to.not.have.property('prev');
       });
     });
     it('with zero limit', function() {


### PR DESCRIPTION
It adds the previous and next page index only if there is a page to go in their respective directions.

Some template engines don't let you do the math on the template side very easily and this way everything that is needed is encapsulated in the same object.