### PR TITLE
Fixed deprecations warning on count

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ function paginate(query, options, callback) {
     }
     promises = {
       docs: docsQuery.exec(),
-      count: this.count(query).exec()
+      count: this.countDocuments(query).exec()
     };
     if (lean && leanWithId) {
       promises.docs = promises.docs.then((docs) => {


### PR DESCRIPTION
Fixed  deprecation warning:

DeprecationWarning: collection.count is deprecated, and will be removed in a future version. Use collection.countDocuments or collection.estimatedDocumentCount instead